### PR TITLE
Add `withheld` columns to people and organizations tables

### DIFF
--- a/metab_import.py
+++ b/metab_import.py
@@ -50,7 +50,8 @@ def get_organizations(sup_cur):
     orgs = {}
     sup_cur.execute("""\
                     SELECT id, name, type, parent_id
-                    FROM organizations""")
+                    FROM organizations
+                    WHERE withheld = FALSE""")
     for row in sup_cur:
         org = Organization()
         org.org_id = row[0]
@@ -81,6 +82,7 @@ def get_people(sup_cur):
     sup_cur.execute("""\
             SELECT id, first_name, last_name, display_name, email, phone
             FROM people
+            WHERE withheld = FALSE
             JOIN names
             ON id=person_id""")
     for row in sup_cur:
@@ -161,8 +163,8 @@ def get_projects(mwb_cur, sup_cur, people, orgs):
             sup_cur.execute("""\
                         SELECT id, parent_id
                         FROM organizations
-                        WHERE name=%s""",
-                        (institute,)) 
+                        WHERE name=%s AND withheld = FALSE""",
+                        (institute,))
             try:
                 inst_id = sup_cur.fetchone()[0]
                 project.institute_uri = orgs[inst_id].uri
@@ -175,8 +177,8 @@ def get_projects(mwb_cur, sup_cur, people, orgs):
             sup_cur.execute("""\
                         SELECT id, parent_id
                         FROM organizations
-                        WHERE name=%s""",
-                        (department,)) 
+                        WHERE name=%s AND withheld = FALSE""",
+                        (department,))
             try:
                 dept_options = {}
                 for row in sup_cur:
@@ -193,8 +195,8 @@ def get_projects(mwb_cur, sup_cur, people, orgs):
             sup_cur.execute("""\
                         SELECT id, parent_id
                         FROM organizations
-                        WHERE name=%s""",
-                        (lab,)) 
+                        WHERE name=%s AND withheld = FALSE""",
+                        (lab,))
             try:
                 lab_options = {}
                 for row in sup_cur:
@@ -280,8 +282,8 @@ def get_studies(mwb_cur, sup_cur, people, orgs):
             sup_cur.execute("""\
                         SELECT id, parent_id
                         FROM organizations
-                        WHERE name=%s""",
-                        (institute,)) 
+                        WHERE name=%s AND withheld = FALSE""",
+                        (institute,))
             try:
                 inst_id = sup_cur.fetchone()[0]
                 study.institute_uri = orgs[inst_id].uri
@@ -294,8 +296,8 @@ def get_studies(mwb_cur, sup_cur, people, orgs):
             sup_cur.execute("""\
                         SELECT id, parent_id
                         FROM organizations
-                        WHERE name=%s""",
-                        (department,)) 
+                        WHERE name=%s AND withheld = FALSE""",
+                        (department,))
             try:
                 dept_options = {}
                 for row in sup_cur:
@@ -312,8 +314,8 @@ def get_studies(mwb_cur, sup_cur, people, orgs):
             sup_cur.execute("""\
                         SELECT id, parent_id
                         FROM organizations
-                        WHERE name=%s""",
-                        (lab,)) 
+                        WHERE name=%s AND withheld = FALSE""",
+                        (lab,))
             try:
                 lab_options = {}
                 for row in sup_cur:

--- a/mwb_supplemental.pgsql
+++ b/mwb_supplemental.pgsql
@@ -1,6 +1,6 @@
 -- mwb_supplemental
 
--- For tables have a "withheld" column, if set (to TRUE), then the importer
+-- For tables with a "withheld" column, if set (to TRUE), then the importer
 -- should not generate triples for the record.
 
 CREATE TABLE IF NOT EXISTS public.people

--- a/mwb_supplemental.pgsql
+++ b/mwb_supplemental.pgsql
@@ -1,11 +1,15 @@
 -- mwb_supplemental
 
+-- For tables have a "withheld" column, if set (to TRUE), then the importer
+-- should not generate triples for the record.
+
 CREATE TABLE IF NOT EXISTS public.people
 (
     id           SERIAL  PRIMARY KEY,
     display_name TEXT,
     email        TEXT,
-    phone        TEXT
+    phone        TEXT,
+    withheld     BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE IF NOT EXISTS public.organizations
@@ -13,7 +17,8 @@ CREATE TABLE IF NOT EXISTS public.organizations
     id        SERIAL  PRIMARY KEY,
     name      TEXT    NOT NULL,
     type      TEXT    NOT NULL, -- institute, department, or laboratory
-    parent_id INTEGER REFERENCES public.organizations(id)
+    parent_id INTEGER REFERENCES public.organizations(id),
+    withheld  BOOLEAN NOT NULL DEFAULT FALSE
 
     UNIQUE(name, type, parent_id)
 );


### PR DESCRIPTION
When set, `withheld` indicates that the record should not be used to generate triples. This can be used to exclude old or bad data.