### PR TITLE
Add support for photos

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -18,6 +18,10 @@ vivo_password: "vivo_password"
 update_endpoint: "http://vivo.domain.info/api/sparqlUpdate"
 namespace: "https://vivo.domain.info/individual/"
 
+# Path to the Tools information
+tools: "tools.yaml"
+
 # Admin Page Requirements
-picturepath: 'pictures'
-secret: 'secret_hex_string'
+secret: "CHANGE ME! DO NOT leave this as is."
+picturepath: "pics"
+file_storage_alias: "a"

--- a/metab_admin.py
+++ b/metab_admin.py
@@ -172,7 +172,7 @@ def upload_image():
                 <button class="btn btn-primary" type=submit>Upload</button>
             </form>
 
-            <img id="current" style="width: 200; height: auto;" alt="Current Photo" />
+            <img id="current" style="width: 200px; height: auto;" alt="Current Photo" />
         </div>
         <script>
             const displayNameInput = document.getElementById('searchInput');

--- a/metab_admin.py
+++ b/metab_admin.py
@@ -25,7 +25,6 @@ import psycopg2
 import psycopg2.errorcodes
 
 import metab_classes
-import metab_import
 
 # Globals
 app = Blueprint('metab_admin', __name__)
@@ -33,7 +32,6 @@ app = Blueprint('metab_admin', __name__)
 conn = None
 picture_path = '.'
 file_storage_alias = 'b'
-aide = None
 
 INST_TYPE = 'institute'
 DEPT_TYPE = 'department'
@@ -94,7 +92,6 @@ def upload_image():
             pic: werkzeug.datastructures.FileStorage = request.files['picture']
             extension: str = pic.filename.split('.')[-1]
             person_id: str = request.form['person_id']
-            update_triples: bool = request.form.get('update_triples') == 'on'
 
             person_id = person_id.strip()
 
@@ -108,33 +105,8 @@ def upload_image():
 
             pic.save(path)
 
-            if not update_triples:
-                flash('Completed save sucessfully')
-                return redirect(request.url)
-
-            triples = photo.get_triples(aide.namespace)
-            triples = [t + ' . ' for t in triples]
-            triples = '\n'.join(triples)
-            query = f'''
-                DELETE DATA {{
-                    GRAPH <http://vitro.mannlib.cornell.edu/default/vitro-kb-2> {{
-                            {triples}
-                        }}
-                }} ;
-                INSERT DATA {{
-                    GRAPH <http://vitro.mannlib.cornell.edu/default/vitro-kb-2> {{
-                            {triples}
-                        }}
-                }}
-            '''
-
-            if aide.do_update(query):
-                flash('Completed save sucessfully')
-                return redirect(request.url)
-
-            flash('Completed upload sucessfully, but SPARQL failed to update')
+            flash('Completed save sucessfully')
             return redirect(request.url)
-
         except Exception:
             logging.exception('upload_image')
             flash('Error uploading file')
@@ -197,17 +169,10 @@ def upload_image():
                     <input type="file" class="form-control-file" id="inputGroupFile01" name=picture>
                 </div>
 
-                <div class="form-group">
-                    <label>Update Triples?</label>
-                    <input id=update_triples class="form-control" type=checkbox name=update_triples>
-                </div>
-
                 <button class="btn btn-primary" type=submit>Upload</button>
             </form>
 
-            <hr />
-            <p>Old photo</p>
-            <img id="current" style="width: 200px; height: auto;" alt="Old Photo" />
+            <img id="current" style="width: 200px; height: auto;" alt="Current Photo" />
         </div>
         <script>
             const displayNameInput = document.getElementById('searchInput');
@@ -729,7 +694,6 @@ def main():
     global conn
     global picture_path
     global file_storage_alias
-    global aide
 
     if len(sys.argv) < 2:
         print(__doc__)
@@ -752,11 +716,6 @@ def main():
         db_user = config_map['sup_username']
         db_password = config_map['sup_password']
         db_port = config_map['sup_port']
-
-        aide = metab_import.Aide(config_map.get('update_endpoint'),
-                                config_map.get('vivo_email'),
-                                config_map.get('vivo_password'),
-                                config_map.get('namespace'))
 
     try:
         conn = psycopg2.connect(database=db_database, user=db_user, password=db_password, host=db_host, port=db_port)

--- a/metab_admin.py
+++ b/metab_admin.py
@@ -100,9 +100,7 @@ def upload_image():
             dirname = photo.path()
             os.makedirs(dirname, exist_ok=True)
 
-            filename = secure_filename(f'photo.{extension}')
-            path = os.path.join(dirname, filename)
-
+            path = os.path.join(dirname, photo.filename())
             pic.save(path)
 
             flash('Completed save sucessfully')

--- a/metab_admin.py
+++ b/metab_admin.py
@@ -116,7 +116,7 @@ def upload_image():
             <div class="row">
                 <h1 class="mx-auto">Upload new profile picture</h1>
             </div>
-            <a href="{{ url_for('main_menu') }}">Back to Home</a>
+            <a href="{{ url_for('metab_admin.main_menu') }}">Back to Home</a>
             {% with messages = get_flashed_messages() %}
                 {% if messages %}
                     {% for message in messages %}

--- a/metab_classes.py
+++ b/metab_classes.py
@@ -163,23 +163,25 @@ class Person(object):
 
 
 class Photo(object):
-    def __init__(self, file_storage_root: str, person_id: str, extension: str):
+    def __init__(self, file_storage_root: str, person_id: str, extension: str,
+                 file_storage_alias: str = "b"):
         self.root = file_storage_root
         self.person_id = person_id
         assert int(self.person_id)
+        self.alias = file_storage_alias
 
         extension = extension.lower()
-        assert extension in ('png', 'jpeg', 'jpg')
-        self.extension = 'jpg'
-        self.mimetype = 'image/jpeg'
-        if extension == 'png':
-            self.extension = 'png'
-            self.mimetype = 'image/png'
+        assert extension in ("png", "jpeg", "jpg")
+        self.extension = "jpg"
+        self.mimetype = "image/jpeg"
+        if extension == "png":
+            self.extension = "png"
+            self.mimetype = "image/png"
 
-    def download_url(self):
+    def download_url(self) -> str:
         return f"/file/p{self.person_id}/{self.filename()}"
 
-    def filename(self):
+    def filename(self) -> str:
         return f"photo.{self.extension}"
 
     def get_triples(self, namespace: typing.Text) -> typing.List[typing.Text]:
@@ -213,10 +215,10 @@ class Photo(object):
 
         return rdf
 
-    def path(self):
+    def path(self) -> str:
         """Get the directory path for the specified person with `person_id`."""
         # "b~" is shorthand for https://vivo.metabolomics.info/individual/
-        path = f"b~p{self.person_id}"
+        path = f"{self.alias}~p{self.person_id}"
         # VIVO expects each directory to be no longer than 3 characters.
         # See: https://wiki.duraspace.org/display/VIVODOC110x/Image+storage
         path = textwrap.wrap(path, 3)

--- a/metab_import.py
+++ b/metab_import.py
@@ -24,6 +24,7 @@ from aide import Aide
 from metab_classes import Dataset
 from metab_classes import Organization
 from metab_classes import Person
+from metab_classes import Photo
 from metab_classes import Project
 from metab_classes import Study
 from metab_classes import Tool
@@ -122,6 +123,37 @@ def link_people_to_org(sup_cur, people, orgs):
         for row in sup_cur:
             triples.extend(orgs[row[1]].add_person(person.uri))
     return triples
+
+
+def make_photos(namespace: str, photos: list):
+    print("Making Photo triples")
+
+    triples = []
+    for photo in photos:
+        triples.extend(photo.get_triples(namespace))
+
+    print(f"There are {len(photos)} photos.")
+
+    return triples
+
+
+def get_photos(file_storage_root: str, people):
+    photos = []
+    for person in people.values():
+        photo = Photo(file_storage_root, person.person_id, 'jpg')
+
+        jpg = os.path.join(photo.path(), photo.filename())
+        if os.path.isfile(jpg):
+            photos.append(photo)
+            continue
+
+        photo = Photo(file_storage_root, person.person_id, 'png')
+        png = os.path.join(photo.path(), photo.filename())
+        if os.path.isfile(png):
+            photos.append(photo)
+            continue
+
+    return photos
 
 
 def get_projects(mwb_cur, sup_cur, people, orgs):
@@ -500,6 +532,7 @@ def main():
     study_file = os.path.join(path, 'studies.rdf')
     dataset_file = os.path.join(path, 'datasets.rdf')
     tools_file = os.path.join(path, 'tools.rdf')
+    photos_file = os.path.join(path, 'photos.rdf')
 
     config = get_config(config_path)
 
@@ -524,6 +557,11 @@ def main():
     people_triples = make_people(aide.namespace, people)
     people_triples.extend(link_people_to_org(sup_cur, people, orgs))
     print_to_file(people_triples, people_file)
+
+    # Photos
+    photos = get_photos(config.get("picturepath", "."), people)
+    photos_triples = make_photos(aide.namespace, photos)
+    print_to_file(photos_triples, photos_file)
 
     # Tools
     tools = get_tools(config)

--- a/metab_import.py
+++ b/metab_import.py
@@ -608,6 +608,8 @@ def main():
     print("Datasets uploaded")
     do_upload(aide, tools_triples)
     print("Tools uploaded")
+    do_upload(aide, photos_triples)
+    print("Photos uploaded")
     do_upload(aide, summary_triples, 1)
     print("Summaries uploaded")
 


### PR DESCRIPTION
These changes add the concept of `Photo` to the `metab_classes.py`, which is used by `metab_import.py` to generate triples. The VIVO file storage strategy is assumed and the admin forms (`metab_admin.py`) support this for both uploading a new photo and viewing someone's current picture.

Note: uploading a photo does not immediately update the VIVO backend. This is still handled by `metab_import.py`.