### PR TITLE
Add import of Metabolomics Tools from Metabolomics Tools Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Setup a Python Virtual Environment, then install the required dependencies.
 
 ## Preparing your config file
 
-To run the importer, you will need a config file containing two sections: one related to the Postgres database, and one related to accessing VIVO. The Postgres section includes credentials for accessing the database, the open port you used to set up the SSH tunnel, and the name of the database. The VIVO section includes credentials for accessing the VIVO query API, as well as the query endpoint and the namespace used for VIVO URIs. There is an example config file with the required fields.
+To run the importer, you will need a config file containing two sections: one related to the Postgres database, and one related to accessing VIVO. The Postgres section includes credentials for accessing the database, the open port you used to set up the SSH tunnel, and the name of the database. The VIVO section includes credentials for accessing the VIVO query API, as well as the query endpoint and the namespace used for VIVO URIs. There is an example config file with the required fields. Download a CSV export from the [Metabolomics Software Tools](https://docs.google.com/spreadsheets/d/1a096jlzbAwTxUdvTtJB2bwfkBRdDcMKrkywS8YZf344/edit?usp=sharing) and note the file name in the config for 'csv_tools'.
 
 
 ## Connect to the database

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -20,6 +20,7 @@ namespace: "https://vivo.domain.info/individual/"
 
 # Path to the Tools information
 tools: "tools.yaml"
+csv_tools: "tools.csv"
 
 # Admin Page Requirements
 secret: "CHANGE ME! DO NOT leave this as is."

--- a/metab_classes.py
+++ b/metab_classes.py
@@ -282,12 +282,15 @@ class Tool(object):
         license = data.get('license', dict(kind=''))
         self.license: Tool.License = Tool.License(**license)
         self.tags: typing.List[typing.Text] = data.get('tags', [])
+        self.pmid: typing.Text = data.get('pmid', None)
 
     def uri(self, namespace: typing.Text) -> typing.Text:
         encoded = self.tool_id
         encoded = encoded.replace('_', '__')
         encoded = encoded.replace('-', '_d')
         encoded = encoded.replace('/', '_s')
+        encoded = encoded.replace('?', '_p')
+        encoded = encoded.replace('=', '_e')
 
         contains_unhandled_char = re.search('[^A-Za-z0-9._/]', encoded)
         if contains_unhandled_char:

--- a/metab_import.py
+++ b/metab_import.py
@@ -519,7 +519,7 @@ def make_datasets(namespace, datasets, studies):
     return dataset_triples, study_triples
 
 
-def get_authors_pmid(aide: Aide, pmid: typing.Text):
+def get_authors_pmid(aide: Aide, pmid: typing.Text) -> typing.List[typing.Dict]:
     count = 0
     authors = []
     redo = True
@@ -561,7 +561,7 @@ def get_yaml_tools(config):
         return []
 
 
-def strip_http(url: typing.Text):
+def strip_http(url: typing.Text) -> typing.Text:
     return url.replace('http://', '').replace('https://', '')
 
 

--- a/metab_import.py
+++ b/metab_import.py
@@ -25,10 +25,13 @@ Instructions:
 """
 
 from datetime import datetime
+from typing import List
+import csv
 import getopt
 import os
 import pathlib
 import sys
+import time
 import typing
 import yaml
 
@@ -516,7 +519,29 @@ def make_datasets(namespace, datasets, studies):
     return dataset_triples, study_triples
 
 
-def get_tools(config):
+def get_authors_pmid(aide: Aide, pmid: typing.Text):
+    count = 0
+    authors = []
+    redo = True
+    while redo and count < 2:
+        count += 1
+        redo = False
+        try:
+            data = aide.get_details([pmid])
+            for author in data['PubmedArticle'][0]['MedlineCitation']['Article']['AuthorList']:
+                authors.append({
+                    'name': f"{author['ForeName'].split(' ')[0].strip()} {author['LastName']}"
+                })
+        except IOError:
+            print('Error getting PubMed Data for tool with PMID %s. Trying again in 3 seconds' % pmid)
+            redo = True
+            time.sleep(3)
+        except Exception:
+            print('Error parsing PubMed Data for tool with PMID %s' % pmid)
+    return authors
+
+
+def get_yaml_tools(config):
     try:
         tools_path = config.get('tools', 'tools.yaml')
         with open(tools_path, 'r') as tools_file:
@@ -533,6 +558,42 @@ def get_tools(config):
             return tools
     except Exception:
         print('Error parsing tools config file: %s' % tools_path)
+        return []
+
+
+def strip_http(url: typing.Text):
+    return url.replace('http://', '').replace('https://', '')
+
+
+def get_csv_tools(config, aide: Aide) -> List[Tool]:
+    try:
+        csv_tools_path = config.get('tools_csv', 'tools.csv')
+        with open(csv_tools_path, 'r') as tools_file:
+            t = csv.reader(tools_file)
+            # Skip the header row
+            next(t)
+
+            tools = []
+            for tool_data in t:
+                pmid = tool_data[19].strip()
+                authors = None
+                if pmid.isnumeric():
+                    authors = get_authors_pmid(aide, pmid)
+                if not tool_data[24].replace('-', '').strip():
+                    continue
+                tool = Tool(strip_http(tool_data[24]), {
+                    'name': tool_data[21],
+                    'description': tool_data[1],
+                    'url': tool_data[24],
+                    'authors': authors,
+                    'pmid': pmid,
+                    'tags': tool_data[6].split(',')
+                })
+                tools.append(tool)
+            return tools
+    except Exception as e:
+        print(e)
+        print('Error parsing tools config file: %s' % csv_tools_path)
         return []
 
 
@@ -659,8 +720,9 @@ def main():
     print_to_file(photos_triples, photos_file)
 
     # Tools
-    tools = get_tools(config)
-    tools_triples = make_tools(aide.namespace, tools, people)
+    yaml_tools = get_yaml_tools(config)
+    csv_tools = get_csv_tools(config, aide)
+    tools_triples = make_tools(aide.namespace, yaml_tools + csv_tools, people)
     print_to_file(tools_triples, tools_file)
 
     # Projects


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

The change reads in a CSV from the [Metabolomics Tools Wiki](https://raspicer.github.io/MetabolomicsTools/AllTools/) and parses the data as Tools. If the Tool has  a PMID it pulls the authors from PubMed.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

JIRA SEP-142

## Verification

_List the steps needed to make sure this thing works. Be precise._

1. From the command-line, run `python3 metab_import config.yaml`.

- Verify the thing does this: 
Printed 10 tools before:
![image](https://user-images.githubusercontent.com/3639154/67806186-c7f86b80-fa68-11e9-921d-563b1639e2ac.png)
Prints 34 tools now: 
![image](https://user-images.githubusercontent.com/3639154/67806113-a7301600-fa68-11e9-8c3f-2f9671e4b110.png)

- Verify the thing does not do that:
Increase the speed of the import. The import is a lot slower now as it has to hit PubMed.

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
