### PR TITLE
Modify metab import to create missing tool authors.

### DIFF
--- a/metab_classes.py
+++ b/metab_classes.py
@@ -332,6 +332,8 @@ class Tool(object):
         encoded = encoded.replace('/', '_s')
         encoded = encoded.replace('?', '_p')
         encoded = encoded.replace('=', '_e')
+        encoded = encoded.replace('&', '_aa')
+        encoded = encoded.replace(':', '_c')
 
         contains_unhandled_char = re.search('[^A-Za-z0-9._/]', encoded)
         if contains_unhandled_char:
@@ -379,20 +381,20 @@ class Tool(object):
 
         return rdf
 
-    def match_authors(self, people: typing.Dict[int, Person]):
-        all_matched = True
+    def match_authors(self, people: typing.Dict[int, Person], namespace: str):
+        non_matched = []
         for author in self.authors:
             for person in people.values():
                 if person.display_name == author.name:
-                    author.uri = person.uri
+                    author.uri = Person.uri(namespace, person.person_id)
                     break
             if author.uri:
                 continue
 
-            all_matched = False
+            non_matched.append(author)
             print(f'Unknown author "{author.name}" for tool: {self.tool_id}')
 
-        return all_matched
+        return non_matched
 
 
 class Publication(object):

--- a/metab_prefill.py
+++ b/metab_prefill.py
@@ -20,6 +20,7 @@ import typing
 import psycopg2
 
 import metab_import
+from metab_import import add_person
 
 
 INSTITUTE = 'institute'
@@ -132,6 +133,8 @@ def add_people(mwb_conn: psycopg2.extensions.connection,
 
         for row in mwb_cur:
             first_name, last_name, institute, department, lab = tuple(row)
+            first_name = first_name.strip()
+            last_name = last_name.strip()
             person_ids = get_person(sup_cur, first_name, last_name)
             if len(person_ids) > 1:
                 print("ERROR: multiple people with same name", file=sys.stderr)
@@ -171,30 +174,6 @@ def add_people(mwb_conn: psycopg2.extensions.connection,
                   .format(first_name, last_name, institute, department, lab))
 
     return
-
-
-def add_person(cursor: psycopg2.extensions.cursor,
-               first_name: str, last_name: str) -> int:
-
-    statement = '''
-        INSERT INTO people (id,      display_name)
-             VALUES        (DEFAULT, %s          )
-          RETURNING id
-    '''
-
-    display_name = '{} {}'.format(first_name, last_name)
-    cursor.execute(statement, (display_name,))
-
-    person_id = cursor.fetchone()[0]
-
-    statement = '''
-        INSERT INTO names (person_id, first_name, last_name)
-             VALUES       (%s       , %s        , %s       )
-    '''
-
-    cursor.execute(statement, (person_id, first_name, last_name))
-
-    return person_id
 
 
 def get_organization(cursor: psycopg2.extensions.cursor, type: str, name: str,


### PR DESCRIPTION
Metab import will now ingest new people for tool authors.

**What does this change do?** _Please be clear and concise._

This change has metab_import create new people for missing authors. This change also fixes two issues. One being people imported with trailing whitespace resulting in non-matching authors. The other being that the Person class was changed from having a uri attribute to function however this was never updated in Tool match_authors. 

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

SEP-142

## Verification

_List the steps needed to make sure this thing works. Be precise._

1. From the command-line, run `python metab_import.py -d config.yaml`

- Here is the new result showing the people being created and there being 204 tools now:
![image](https://user-images.githubusercontent.com/3639154/68706950-cfd30800-055e-11ea-9daa-02307f56a8cd.png)


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
