### PR TITLE
Fix photo upload form to show middle and last name.

### DIFF
--- a/metab_admin.py
+++ b/metab_admin.py
@@ -196,10 +196,10 @@ def upload_image():
 
             displayNameInput.addEventListener('change', (e) => {
                 if (displayNames.includes(e.srcElement.value)) {
-                    const splitName = e.srcElement.value.split(' ');
+                    const splitName = e.srcElement.value.substring(0, e.srcElement.value.indexOf("|")-1).split(' ');
                     const splitId = e.srcElement.value.split(' | ');
                     firstName.value = splitName[0];
-                    lastName.value = splitName[1];
+                    lastName.value = splitName.slice(1).join(" ");
                     if (splitId.length > 0) {
                         personId.value = splitId[1];
 


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

Fix the photo upload form to show the middle and last name in the last name box. It currently just shows the first word after a space. Changed it to show anything after the first word. There are a lot of names that don't fit the first, middle, last construct perfectly and it doesn't impact the actual functionality of uploading a photo.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

JIRA SEP-148

## Verification

_List the steps needed to make sure this thing works. Be precise._

1. Run the metab admin site with
```bash
$ python3 metab_admin.py config.yaml
```

Old form:
![image](https://user-images.githubusercontent.com/3639154/69370376-d7379700-0c6b-11ea-9abd-8744a771bf37.png)

New form:
![image](https://user-images.githubusercontent.com/3639154/69370412-e585b300-0c6b-11ea-8d04-8e36baca7e1f.png)

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
