### PR TITLE
Skip studies that start with ST9

### DIFF
--- a/metab_import.py
+++ b/metab_import.py
@@ -415,6 +415,14 @@ def make_projects(namespace, projects: typing.Mapping[str, Project]):
     return triples, summaries
 
 
+def is_valid_study(study: Study):
+    if study.study_id.startswith('ST9'):
+        # Studies that start with ST9 are testing studies
+        print('Test study found like ST9XXXXX. Skipping...')
+        return False
+    return True
+
+
 def get_studies(mwb_cur, sup_cur, people, orgs):
     print("Gathering Workbench Studies")
     studies = {}
@@ -437,6 +445,10 @@ def get_studies(mwb_cur, sup_cur, people, orgs):
             summary=row[3].replace('\n', '').replace('"', '\\"'),
             submit_date=submit_date,
             project_id=row[5].replace('\n', ''))
+
+        # Skip invalid studies
+        if not is_valid_study(study):
+            continue
 
         last_names: str = row[6]
         first_names: str = row[7]


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

Skip importing studies that start with ST9.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

Studies that start with ST9 are for testing. 
JIRA SEP-151


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. Run the metab_import.py script
`python metab_import.py -d config.yaml`

Here is a screenshot of the studies.nt diff:
![image](https://user-images.githubusercontent.com/3639154/72535715-02db9580-3847-11ea-99e9-437244fad081.png)

Here is a screenshot of the dataset diff:
![image](https://user-images.githubusercontent.com/3639154/72536004-7d0c1a00-3847-11ea-8f2d-d08ffcc037a4.png)



## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
