### PR TITLE
Update pub ingest to use author's top level affiliations.

### DIFF
--- a/metab_pub_ingest.py
+++ b/metab_pub_ingest.py
@@ -135,7 +135,18 @@ def get_supplementals(cur: psycopg2.extensions.cursor, person_id: str = None)\
 
 
 def get_ids(aide: Aide, person: Person, affiliations: typing.List[str]) -> list:
-    query = person.last_name + ', ' + person.first_name + ' [Full Author Name]'
+    ''' Get the PMIDs associated with a person with the passed affilitions.
+        Returns an empty array if no affiliations are passed.
+
+        Here is an example of a full query with a person with first name Arthur, last name Edison, and two affiliations
+
+        Edison Arthur[Author - Full] AND (University of Florida[Affiliation] OR University of Georgia[Affiliation])
+
+        Which PubMed turns into:
+
+        Edison, Arthur[Full Author Name] AND (University of Florida[Affiliation] OR University of Georgia[Affiliation])
+    '''
+    query = person.first_name + ' ' + person.last_name + '[Author - Full]'
     if len(affiliations) > 0:
         query += ' AND ('
         for affiliation in affiliations:
@@ -143,6 +154,9 @@ def get_ids(aide: Aide, person: Person, affiliations: typing.List[str]) -> list:
         # Trim off the trailing OR
         query = query[:-4]
         query += ')'
+    else:
+        print(f'Missing Affiliation for person_id: {person.person_id}. Skipping...')
+        return []
     id_list = aide.get_id_list(query)
     return id_list
 


### PR DESCRIPTION
Update the pub ingest to search pubmed with all top level affiliations of the authors. This gets more accurate results from pubmed than just names.

**What does this change do?** _Please be clear and concise._

Changes the pub ingest to grab the institutes from the supplemental database and use them in the PubMed search query in the form "Author Name[Author - Full] AND (Inst1 [Affiliation] OR ... OR InstN[Affiliation]).

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

There were too many inaccurate matches when searching PubMed by just name.


## Verification

Run the pub ingest and see the output files contain less publications.

```
python3 metab_pub_ingest.py config.yaml all
```

![image](https://user-images.githubusercontent.com/3639154/73013382-35a50100-3de6-11ea-9642-7be9e067bed1.png)

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
