### PR TITLE
Fix add devs crashing when withheld people exist.

### DIFF
--- a/metab_classes.py
+++ b/metab_classes.py
@@ -156,7 +156,8 @@ class Dataset(object):
 
 class Person(object):
     def __init__(self, person_id: str, first_name: str, last_name: str,
-                 display_name: str = "", email: str = "", phone: str = ""):
+                 display_name: str = "", email: str = "", phone: str = "",
+                 withheld: bool = False):
         assert person_id and first_name and last_name
 
         self.person_id = person_id
@@ -165,11 +166,14 @@ class Person(object):
         self.email = email
         self.phone = phone
         self.display_name = display_name
+        self.withheld = withheld
 
         if not self.display_name:
             self.display_name = f"{self.first_name} {self.last_name}"
 
     def get_triples(self, namespace: str):
+        if self.withheld:
+            return []
         uri = Person.uri(namespace, self.person_id)
         rdf = []
         vcard_uri = uri + "vcard"


### PR DESCRIPTION
Fix the add devs from crashing when there are withheld people or names that match the tools. Pass all people to the tools so that it can match these people.

**What does this change do?** _Please be clear and concise._

Prevents --add-devs from crashing when there are people or names that exist and are withheld.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

SEP-158

## Verification

_List the steps needed to make sure this thing works. Be precise._

Run metab_import with production data and see crash. 
Run with this PR and it finishes.

![image](https://user-images.githubusercontent.com/3639154/73298847-176f4480-41dc-11ea-9a5e-0fdc271ffc79.png)


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
