### PR TITLE
Fix typos and add parent ID to withheld orgs

### DIFF
--- a/metab_admin.py
+++ b/metab_admin.py
@@ -330,10 +330,10 @@ def withheld_organizations():
     orgs = []
 
     with conn.cursor() as cur:
-        cur.execute('SELECT id, name, type, withheld from organizations ORDER BY id;')
+        cur.execute('SELECT id, name, type, withheld, parent_id from organizations ORDER BY id;')
         rows = cur.fetchall()
         for row in rows:
-            orgs.append((row[0], row[1], row[2], row[3]))
+            orgs.append((row[0], row[1], row[2], row[3], row[4]))
 
     if request.method == 'POST':
         try:

--- a/templates/withheldorgs.html
+++ b/templates/withheldorgs.html
@@ -1,6 +1,6 @@
 <!doctype html>
     <head>
-        <title>Change Person Withholding</title>
+        <title>Change Organization Withholding</title>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
         <style>
             .hide {
@@ -10,7 +10,7 @@
     </head>
     <body>
         <div class="container mx-auto" style="width: 50%;">
-            <h1 class="mx-auto">Change the withholding status of a person</h1>
+            <h1 class="mx-auto">Change the withholding status of an Organization</h1>
             <a href="{{ url_for('metab_admin.main_menu') }}">Back to Home</a>
             {% with messages = get_flashed_messages() %}
                 {% if messages %}
@@ -29,8 +29,9 @@
                 <thead>
                     <tr>
                         <th scope="col">Id</th>
+                        <th scope="col">Parent</th>
                         <th scope="col">Name</th>
-                        <th scope="col">Email</th>
+                        <th scope="col">Type</th>
                         <th scope="col">Withheld</th>
                     </tr>
                 </thead>
@@ -38,6 +39,7 @@
                     {% for org in orgs %}
                         <tr id="row-{{org.0}}-{{org.1}}-{{org.2}}">
                             <th scope="row">{{ org.0 }}</th>
+                            <td>{{org.4}}</td>
                             <td>{{org.1}}</td>
                             <td>{{org.2}}</td>
                             <td><input type="checkbox" id="check-{{org.0}}" {{ "checked" if org.3 else ""}}></td>


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

Fix the typos on the withheld organization page from copying the withheld person page.
Add a parent ID column to the table so that a user can tell two similar named departments apart.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

SEP-164


## Verification

Before:
![image](https://user-images.githubusercontent.com/3639154/74263168-4c939080-4ccc-11ea-86f2-76f14df2d67f.png)

After:
![image](https://user-images.githubusercontent.com/3639154/74263143-41406500-4ccc-11ea-8ba5-6fe73d337d7c.png)

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
