### PR TITLE
Add existing publications to the edit publications admin page.

### DIFF
--- a/templates/addpmid.html
+++ b/templates/addpmid.html
@@ -38,24 +38,42 @@
                 <input hidden readonly id=id type=text name=id>
 
                 <div class="form-group">
-                    <label>PubMed IDs</label>
-                    <input class="form-control" type=text name=pmid placeholder="separate ids with a comma i.e. 11111, 22222">
+                    <label>Include PubMed IDs</label>
+                    <input id="inclpmid" class="form-control" type=text name=inclpmid placeholder="separate ids with a comma i.e. 11111, 22222">
                 </div>
 
-                <button class="btn btn-primary" type=submit name=include>Add PMID</button>
-                <button class="btn btn-danger" type=submit name=exclude>Exclude PMID</button>
+                <div class="form-group">
+                    <label>Exclude PubMed IDs</label>
+                    <input id="exclpmid" class="form-control" type=text name=exclpmid placeholder="separate ids with a comma i.e. 11111, 22222">
+                </div>
+
+                <button class="btn btn-primary" type=submit name=include>Update PMIDs</button>
             </form>
         </div>
         <script>
+            const include_data = JSON.parse('{{include_pubs | tojson | safe}}');
+            const exclude_data = JSON.parse('{{exclude_pubs | tojson | safe}}');
             const displayNameInput = document.getElementById('searchInput');
             const displayNames = [...document.getElementById('displaynames').childNodes].filter(name => name.value).map(name => name.value);
             const name = document.getElementById('name');
             const id = document.getElementById('id');
+            const inclpmid = document.getElementById('inclpmid');
+            const exclpmid = document.getElementById('exclpmid');
             displayNameInput.addEventListener('change', (e) => {
                 if (displayNames.includes(e.srcElement.value)) {
                     const splitName = e.srcElement.value.split('|');
-                    name.value = splitName[0];
-                    id.value = splitName[1];
+                    const nameValue = splitName[0].trim();
+                    const idValue = splitName[1].trim();
+                    name.value = nameValue;
+                    id.value = idValue;
+                    inclpmid.value = '';
+                    exclpmid.value = '';
+                    if (include_data[idValue]) {
+                        inclpmid.value = include_data[idValue];
+                    }
+                    if (exclude_data[idValue]) {
+                        exclpmid.value = exclude_data[idValue];
+                    }
                 }
             });
         </script>


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

Add ability to view the existing publications when editing them on the edit publication page. Changed the page from include/exclude buttons to including two input boxes and one submit button. This means that you can remove and add publications.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

SEP-167


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. From the command-line, start the admin page: `python metab_admin.py config.yaml`

Before:
![image](https://user-images.githubusercontent.com/3639154/78055797-1086be80-7352-11ea-9e2e-492cb2b5670b.png)

After:
![image](https://user-images.githubusercontent.com/3639154/78055731-f6e57700-7351-11ea-8a61-6e2f2719ec1b.png)


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
