### PR TITLE
Add CRUD to associate person and an org tree

### DIFF
--- a/m3c/static/associateperson.js
+++ b/m3c/static/associateperson.js
@@ -1,0 +1,139 @@
+let assocTree = {};
+const addBtn = document.getElementById('add-btn');
+const displayNameInput = document.getElementById('searchInput');
+const displayNames = [...document.getElementById('displaynames').childNodes]
+    .filter(name => name.value)
+    .map(name => name.value);
+const instituteInput = document.getElementById('institutes');
+const instituteDataList = document.getElementById('insitutes-dl');
+const departmentInput = document.getElementById('departments');
+const departmentDataList = document.getElementById('departments-dl');
+const labInput = document.getElementById('labs');
+const labDataList = document.getElementById('labs-dl');
+const nameField = document.getElementById('name');
+const email = document.getElementById('email');
+const id = document.getElementById('id');
+const messages = document.getElementById('messages');
+const tbody = document.getElementById('t-body');
+const orgTree = document.getElementById('org-tree-root');
+
+const convertToOption = ([orgId, org]) => {
+    const orgOpt = document.createElement('option')
+    orgOpt.value = `${org.orgName} | ${orgId}`;
+    return orgOpt;
+}
+
+displayNameInput.addEventListener('change', (e) => {
+    if (displayNames.includes(e.target.value)) {
+        const splitName = e.target.value.split(' | ');
+        const dispName = splitName[0].trim();
+        const dispEmail = splitName[1].trim();
+        const dispId = splitName[2].trim();
+
+        nameField.value = dispName;
+        email.value = dispEmail;
+        id.value = dispId;
+
+        assocTree = generateTreeData(dispId);
+
+        orgTree.innerHTML = '';
+        buildTree(assocTree, orgTree);
+    } else {
+        instituteInput.innerHTML = '';
+        departmentInput.innerHTML = '';
+        labInput.innerHTML = '';
+    }
+});
+
+labDataList.append(...Object.entries(allOrganizations)
+    .filter(([_orgId, org]) => org.orgType === 'laboratory')
+    .map(convertToOption));
+
+departmentDataList.append(...Object.entries(allOrganizations)
+    .filter(([_orgId, org]) => org.orgType === 'department')
+    .map(convertToOption));
+
+const buildTree = (treeData, rootNode) => {
+    if (!treeData || Object.keys(treeData).length === 0) {
+        return;
+    }
+
+    treeData.forEach((a) => {
+        const orgNode = document.createElement('li');
+        const removeBtn = document.createElement('span');
+        orgNode.textContent = a.orgName;
+        orgNode.id = `org|${a.orgType}|${a.orgId}`;
+
+        removeBtn.textContent = '  ❌';
+        removeBtn.style = 'cursor: pointer;'
+        removeBtn.addEventListener('click', (_e) => {
+            updateAssociation(false, id.value, a.orgId);
+        });
+
+        orgNode.appendChild(removeBtn);
+        rootNode.appendChild(orgNode);
+
+        if (a.children && a.children.length > 0) {
+            const subOrgNode = document.createElement('ul');
+            orgNode.appendChild(subOrgNode);
+            buildTree(a.children, subOrgNode);
+        }
+    })
+}
+
+const generateTreeData = (personId) => {
+    if (!(personId in associationData)) {
+        return {};
+    }
+    const associatedOrgs = associationData[personId];
+
+    const treeMap = new Map();
+    treeMap.set(null, { children: [] })
+    associatedOrgs
+        .map((org) => org.orgId)
+        .forEach((org) => treeMap.set(org, { orgId: org, parent: allOrganizations[org].parentId, orgType: allOrganizations[org].orgType, orgName: allOrganizations[org].orgName, children: [] }))
+    treeMap.forEach((org, _orgId, _map) => {
+        if (treeMap.has(org.parent)) {
+            const parentOrg = treeMap.get(org.parent);
+            org.parent = parentOrg;
+            parentOrg.children.push(org);
+        } else if (org !== null) {
+            treeMap.get(null).children.push(org);
+        }
+    });
+
+    return treeMap.get(null).children.filter((org) => !!org.orgId);
+}
+
+const updateAssociation = (isNew, personId, orgId) => {
+    fetch(window.location.href, {
+        method: isNew ? 'POST' : 'DELETE',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            personId,
+            orgId
+        })
+    }).then(async resp => {
+        messages.innerHTML = '';
+        if (resp.status === 200) {
+            const response = await resp.json();
+            const alertMsg = document.createElement('div');
+            alertMsg.textContent = response.message;
+            alertMsg.className = 'alert alert-success';
+            messages.appendChild(alertMsg);
+
+            associationData = response.assocMap;
+            const newData = generateTreeData(personId);
+            assocTree = newData;
+            orgTree.innerHTML = '';
+            buildTree(assocTree, orgTree);
+        } else {
+            const alertMsg = document.createElement('div');
+            alertMsg.textContent = await resp.text()
+            alertMsg.className = 'alert alert-danger';
+            messages.appendChild(alertMsg);
+        }
+    });
+}

--- a/m3c/static/orgtree.js
+++ b/m3c/static/orgtree.js
@@ -1,0 +1,50 @@
+let assocTree = {};
+const nameField = document.getElementById('name');
+const id = document.getElementById('id');
+const messages = document.getElementById('messages');
+const tbody = document.getElementById('t-body');
+const orgTree = document.getElementById('org-tree-root');
+
+const buildTree = (treeData, rootNode) => {
+    if (!treeData || Object.keys(treeData).length === 0) {
+        return;
+    }
+
+    treeData.forEach((a) => {
+        const orgNode = document.createElement('li');
+        const removeBtn = document.createElement('span');
+        orgNode.textContent = `${a.orgName} - #${a.orgId} - (${associationData[a.orgId]})`;
+        orgNode.id = `org|${a.orgType}|${a.orgId}`;
+        orgNode.className = `node-${a.orgType}`;
+
+        rootNode.appendChild(orgNode);
+
+        if (a.children && a.children.length > 0) {
+            const subOrgNode = document.createElement('ul');
+            orgNode.appendChild(subOrgNode);
+            buildTree(a.children, subOrgNode);
+        }
+    })
+}
+
+const buildFullTree = () => {
+    const treeMap = new Map();
+    treeMap.set(null, {children: []});
+    
+    Object.entries(allOrganizations).forEach(([orgId, org]) => treeMap.set(parseInt(orgId, 10), {...org, children: [], orgId}))
+
+    treeMap.forEach((org, _orgId, _map) => {
+        if (treeMap.has(org.parentId)) {
+            const parentOrg = treeMap.get(org.parentId);
+            parentOrg.children.push(org);
+        } else {
+            treeMap.get(null).children.push(org);
+        }
+    });
+    console.log(treeMap);
+
+    return treeMap.get(null).children.filter((org) => !!org.orgName);
+}
+
+const fullTree = buildFullTree();
+buildTree(fullTree, orgTree);

--- a/m3c/templates/associateperson.html
+++ b/m3c/templates/associateperson.html
@@ -1,12 +1,15 @@
 <!doctype html>
-    <head>
-        <title>Create a new Person</title>
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-    </head>
-    <body>
-        <div class="container mx-auto" style="width: 50%;">
-            <h1 class="mx-auto">Associate a Person with a Inst/Dept/Lab</h1>
-            <a href="{{ url_for('metab_admin.main_menu') }}">Back to Home</a>
+<head>
+    <title>Modify a Person's Associations</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW" crossorigin="anonymous"></script>
+</head>
+<body>
+    <div class="container mx-auto" style="width: 50%;">
+        <h1 class="mx-auto">Associate a Person with a Inst/Dept/Lab</h1>
+        <a href="{{ url_for('metab_admin.main_menu') }}">Back to Home</a>
+
+        <div id="messages">
             {% with messages = get_flashed_messages() %}
                 {% if messages %}
                     {% for message in messages %}
@@ -16,6 +19,9 @@
                     {% endfor %}
                 {% endif %}
             {% endwith %}
+        </div>
+
+        <form method="post" enctype="multipart/form-data">
 
             <div class="form-group">
                 <label>Search Display Name</label>
@@ -27,65 +33,58 @@
                 </datalist>
             </div>
 
-            <form method=post enctype=multipart/form-data>
-                <div class="form-group">
-                    <label>Name</label>
-                    <input readonly id=name class="form-control" type=text name=name>
-                </div>
+            <div class="form-group">
+                <label>Name</label>
+                <input readonly id=name class="form-control" type=text name=name>
+            </div>
 
-                <div class="form-group">
-                    <label>Email</label>
-                    <input readonly id=email class="form-control" type=text name=email>
-                </div>
+            <div class="form-group">
+                <label>Email</label>
+                <input readonly id=email class="form-control" type=text name=email>
+            </div>
 
-                <input hidden readonly id=id type=text name=id>
+            <input hidden readonly id=id type=text name=id>
 
-                <div class="form-group">
-                    <label>Institute</label>
-                    <input class="form-control" list=institutes name=institute>
-                    <datalist id=institutes>
-                        {% for inst in instituteList %}
-                            <option value="{{inst}}">
-                        {% endfor %}
-                    </datalist>
-                </div>
+            <a target="_blank" href="{{ url_for('metab_admin.org_tree') }}">View the Organization Tree For IDs</a>
 
-                <div class="form-group">
-                    <label>Department</label>
-                    <input class="form-control" list=departments name=department>
-                    <datalist id=departments>
-                        {% for dept in departmentList %}
-                            <option value="{{dept}}">
-                        {% endfor %}
-                    </datalist>
-                </div>
+            <div class="form-group">
+                <label>Institute</label>
+                <input class="form-control" list="institutes-dl" name="institute" id="institutes">
+                <datalist id="institutes-dl">
+                {% for orgId, org in organizations.items() %}
+                    {% if org['orgType'] == 'institute' %}
+                        <option value="{{org['orgName']}} | {{orgId}}">
+                    {% endif %}
+                {% endfor %}
+                </datalist>
+            </div>
 
-                <div class="form-group">
-                    <label>Labs</label>
-                    <input class="form-control" list=labs name=lab>
-                    <datalist id=labs>
-                        {% for labItem in labList %}
-                            <option value="{{labItem}}">
-                        {% endfor %}
-                    </datalist>
-                </div>
+            <div class="form-group">
+                <label>Department</label>
+                <input class="form-control" list="departments-dl" name=department id="departments">
+                <datalist id="departments-dl">
+                </datalist>
+            </div>
 
-                <button class="btn btn-primary" type="submit">Associate Person</button>
-            </form>
-        </div>
-        <script>
-            const displayNameInput = document.getElementById('searchInput');
-            const displayNames = [...document.getElementById('displaynames').childNodes].filter(name => name.value).map(name => name.value);
-            const name = document.getElementById('name');
-            const email = document.getElementById('email');
-            const id = document.getElementById('id');
-            displayNameInput.addEventListener('change', (e) => {
-                if (displayNames.includes(e.srcElement.value)) {
-                    const splitName = e.srcElement.value.split('|');
-                    name.value = splitName[0];
-                    email.value = splitName[1];
-                    id.value = splitName[2];
-                }
-            });
-        </script>
-    </body>
+            <div class="form-group">
+                <label>Labs</label>
+                <input class="form-control" list="labs-dl" name=lab id="labs">
+                <datalist id="labs-dl">
+                </datalist>
+            </div>
+
+            <button class="btn btn-primary" type="submit" id="add-btn">Add New Association</button>
+
+            <div class="form-group">
+                <label>Current Associations (childen will be removed if parent is removed)</label>
+                <ul class="org-tree" id="org-tree-root">
+                </ul>
+            </div>
+        </form>
+    </div>
+    <script>
+        let associationData = {{ assocMap|tojson|safe }};
+        const allOrganizations = {{ organizations|tojson|safe }};
+    </script>
+    <script src="{{url_for('static', filename='associateperson.js')}}"></script>
+</body>

--- a/m3c/templates/index.html
+++ b/m3c/templates/index.html
@@ -36,6 +36,9 @@
             <div class="row my-3">
                 <a class="btn btn-info w-100" href="{{ url_for('metab_admin.person_overview') }}">Add or Edit a Person's Overview</a>
             </div>
+            <div class="row my-3">
+                <a class="btn btn-info w-100" href="{{ url_for('metab_admin.org_tree') }}">View the Organization Tree</a>
+            </div>
         </div>
     </body>
 </html>

--- a/m3c/templates/orgtree.html
+++ b/m3c/templates/orgtree.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<head>
+    <title>View Org Tree</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW" crossorigin="anonymous"></script>
+</head>
+<body>
+    <div class="container mx-auto" style="width: 50%;">
+        <h1 class="mx-auto">View the org-tree</h1>
+        <a href="{{ url_for('metab_admin.main_menu') }}">Back to Home</a>
+
+        <div id="messages">
+            {% with messages = get_flashed_messages() %}
+                {% if messages %}
+                    {% for message in messages %}
+                        <div class="alert alert-warning" role="alert">
+                            {{ message }}
+                        </div>
+                    {% endfor %}
+                {% endif %}
+            {% endwith %}
+        </div>
+
+        <div class="form-group">
+            <label>All orginzations in the form (OrgName - #OrgId - (#OfPeopleAssociated)</label>
+            <ul class="org-tree" id="org-tree-root">
+            </ul>
+        </div>
+    </div>
+    <script>
+        let associationData = {{ assocMap|tojson|safe }};
+        const allOrganizations = {{ organizations|tojson|safe }};
+    </script>
+    <script src="{{url_for('static', filename='orgtree.js')}}"></script>
+</body>

--- a/m3c/templates/personalias.html
+++ b/m3c/templates/personalias.html
@@ -17,7 +17,7 @@
                     {% endfor %}
                 {% endif %}
             {% endwith %}
-                        </div>
+            </div>
 
             <div class="form-group">
                 <label>Search Display Name</label>
@@ -120,7 +120,9 @@
                             newFirst.value = '';
                             newLast.value = '';
                         } else {
-                            aliasData[personId].splice(aliasData[personId].findIndex(a => a.first === firstName && a.last === lastName), 1);
+                            aliasData[personId]
+                                .splice(aliasData[personId]
+                                .findIndex(a => a.first === firstName && a.last === lastName), 1);
                         }
                         updateTable(aliasData[personId]);
                     } else {


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

Add the ability to create and delete to person associations and an org tree page to pick the correct ID.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

M3C-222

## Verification

_List the steps needed to make sure this thing works. Be precise._

1. Run the program with `PYTHONPATH=. python m3c serve config.yml`
2. Navigate to `Associate a Person with a Inst/Dept/Lab`
3. Select a person
4. Add an institute/dept/lab. Delete one. Refresh and see it persists.

Sample photos:

![image](https://user-images.githubusercontent.com/3639154/107676129-cc00ca80-6c66-11eb-8351-095ed7760935.png)

![image](https://user-images.githubusercontent.com/3639154/107676166-d4f19c00-6c66-11eb-9724-72c6ea8eb63a.png)



## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
