### PR TITLE
Include the institutes and departments that have ambiguous children

### DIFF
--- a/m3c/prefill.py
+++ b/m3c/prefill.py
@@ -53,6 +53,15 @@ class AmbiguousNamesError(AmbiguityError):
         super().__init__(msg)
 
 
+def error(*values, sep=' ', end='\n', flush=False) -> None:
+    """
+    Prints values to `stderr` instead of `stdout`.
+
+    Equivalent to `print(*values, file=sys.stderr)`.
+    """
+    print(*values, sep=sep, end=end, file=sys.stderr, flush=flush)
+
+
 def add_developers(sup_cur: db.Cursor) -> None:
     pmids = set(tools.MetabolomicsToolsWiki.pmids())
     total = len(pmids)
@@ -136,8 +145,18 @@ def add_organizations(sup_cur: db.Cursor,
     dcnt = len(departments)
     lcnt = len(laboratories)
 
-    if not(dcnt in [1, lcnt] and icnt in [1, dcnt]):
-        raise AmbiguousHierarchyError(record)
+    if dcnt not in [1, lcnt]:
+        error(record.psid, AmbiguousHierarchyError.__name__, AmbiguousHierarchyError(record))
+        error('Continuing with creation of institutes.')
+        departments = [""] * len(institutes)
+        laboratories = [""] * len(institutes)
+        dcnt = len(departments)
+        lcnt = len(laboratories)
+    elif icnt not in [1, dcnt]:
+        error(record.psid, AmbiguousHierarchyError.__name__, AmbiguousHierarchyError(record))
+        error('Continuing with creation of institutes and departments.')
+        laboratories = [""] * len(institutes)
+        lcnt = len(laboratories)
 
     institute_ids = []
     for i, institute in enumerate(institutes):
@@ -311,15 +330,6 @@ def associate(sup_cur: db.Cursor, psid: str, person_id: int, institute_id: int,
 
 def bad_email(email: str) -> bool:
     return ' ' in email
-
-
-def error(*values, sep=' ', end='\n', flush=False) -> None:
-    """
-    Prints values to `stderr` instead of `stdout`.
-
-    Equivalent to `print(*values, file=sys.stderr)`.
-    """
-    print(*values, sep=sep, end=end, file=sys.stderr, flush=flush)
 
 
 def main():

--- a/m3c/prefill.py
+++ b/m3c/prefill.py
@@ -145,17 +145,17 @@ def add_organizations(sup_cur: db.Cursor,
     dcnt = len(departments)
     lcnt = len(laboratories)
 
-    if dcnt not in [1, lcnt]:
+    if dcnt != icnt and icnt != 1:
         error(record.psid, AmbiguousHierarchyError.__name__, AmbiguousHierarchyError(record))
         error('Continuing with creation of institutes.')
         departments = [""] * len(institutes)
         laboratories = [""] * len(institutes)
         dcnt = len(departments)
         lcnt = len(laboratories)
-    elif icnt not in [1, dcnt]:
+    elif lcnt != dcnt and dcnt != 1:
         error(record.psid, AmbiguousHierarchyError.__name__, AmbiguousHierarchyError(record))
         error('Continuing with creation of institutes and departments.')
-        laboratories = [""] * len(institutes)
+        laboratories = [""] * len(departments)
         lcnt = len(laboratories)
 
     institute_ids = []

--- a/tests/test_prefill.py
+++ b/tests/test_prefill.py
@@ -90,8 +90,9 @@ class TestPrefill(unittest.TestCase):
                           department="Biology",
                           laboratory="Bobby")
         cursor = MockDatabaseConnection().cursor()
-        with self.assertRaises(prefill.AmbiguityError):
-            prefill.add_organizations(cursor, rec)
+        prefill.add_organizations(cursor, rec)
+        expected = ["UF", "FSU"]
+        self.assertListEqual(organizations, expected)
 
     def test_multiname_fewer_labs_than_departments_errors(self):
         # Ambiguity: which department does the lab belong to?
@@ -99,8 +100,9 @@ class TestPrefill(unittest.TestCase):
                           department="Biology;Chem",
                           laboratory="Bobby")
         cursor = MockDatabaseConnection().cursor()
-        with self.assertRaises(prefill.AmbiguityError):
-            prefill.add_organizations(cursor, rec)
+        prefill.add_organizations(cursor, rec)
+        expected = ["UF", "Biology", "Chem"]
+        self.assertListEqual(organizations, expected)
 
     def test_multiname_too_many_labs(self):
         # Ambiguity: which department does the last lab belong to?
@@ -108,8 +110,9 @@ class TestPrefill(unittest.TestCase):
                           department="Biology;Chem",
                           laboratory="Bobby;Jones;Davis")
         cursor = MockDatabaseConnection().cursor()
-        with self.assertRaises(prefill.AmbiguityError):
-            prefill.add_organizations(cursor, rec)
+        prefill.add_organizations(cursor, rec)
+        expected = ["UF", "FSU", "Biology", "Chem"]
+        self.assertListEqual(organizations, expected)
 
     def test_multiname_too_many_departments(self):
         # Ambiguity: which institute does the last department belong to?
@@ -117,8 +120,9 @@ class TestPrefill(unittest.TestCase):
                           department="Biology;Chem;Yo",
                           laboratory="Bobby;Jones;Davis")
         cursor = MockDatabaseConnection().cursor()
-        with self.assertRaises(prefill.AmbiguityError):
-            prefill.add_organizations(cursor, rec)
+        prefill.add_organizations(cursor, rec)
+        expected = ["UF", "FSU"]
+        self.assertListEqual(organizations, expected)
 
     def test_multiname_single_person(self):
         rec = make_record(last_name="Bond", first_name="James")


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

Instead of skipping the parents of ambiguous children this allows them to be created.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

M3C-267


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. See the issue comments on JIRA for how to restore the backups
2. Modify the config.yml to point to your local databases
3. Run the prefill step from the README
4. You can optionally comment these lines to reduce the time it takes to run the next step: https://github.com/ctsit/m3c-tools/blob/5420081dd7022c5157f4b1515a6c435b54b2d24d/m3c/triples.py#L812-L814
5. Run the generate step
6. Ensure that the process finishes. 

I have attached a diff of the output triple files to the JIRA issue for you to see.

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
